### PR TITLE
OS X Permissions fix

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,8 +36,8 @@ Vagrant.configure(2) do |config|
   # Share an additional folder to the guest VM. The first argument is
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
-  # argument is a set of non-required options.
-  config.vm.synced_folder "../magento2", "/var/www/magento2"
+  # argument is a set of non-required options.  
+  config.vm.synced_folder "../magento2", "/var/www/magento2", :mount_options => ["dmode=777","fmode=666"]
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.


### PR DESCRIPTION
Using Vagrant 1.6.5 with Virtual Box 4.3.2 on OS X 10.10.1 (Yosemite), the default vagrant setup results in a number of permissions errors that prevent Magento from running.  Magento can't write to the `var/cache` folder or the `var/generation` folder, and new folders/files created from a web context seem to ignore PHP's umask setting and are created without the necessary write permissions. 

Having the `/var/www/magento2` folder sync with 

    config.vm.synced_folder "../magento2", "/var/www/magento2", :mount_options => ["dmode=777","fmode=666"]
  
appears to fix this problem, ("appears to" because I'm not familiar enough with how Vagrant handles permissions, umasks, etc. between the host/guest OS to know for certain that this has completely solved the problem)  

Assuming this doesn't interfere with other systems, it'd be a good idea to ship with this as the default so Mac users don't run into this problem.  