### PR TITLE
Add a private ip address.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  # config.vm.network "private_network", ip: "192.168.33.10"
+  config.vm.network "private_network", ip: "33.33.33.33"
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on


### PR DESCRIPTION
You have a forwarded port, which is a very well published feature of Vagrant. Unfortunately, it's inferior to giving your box an IP address in almost every way.

With a private IP address, you can easily connect to a box via SSH. This might seem unnecessary, considering the `vagrant ssh` command, but it comes in handy for making boxes more performant (for now, trust me on this one).

The next thing it does is make urls more pretty. With a forwarded port, you are stuck with appending a port number to every url. This becomes really confusing in Magento 1, because it validates base urls. And then localhost:8080 is the base url, but that is actually an address listened to on port 80. I assume Magento 2 has a similar mechanism (, as much as I might wish it didn't).

If you wish to have one Vagrant box per client, you will run out of nice port numbers to use way before you run out of good IP addresses. It is undeniably an issue that we have to police these for ourselves, but I have yet to think of a better way, and apparently, so has everybody else. And it makes for really obscure local urls, which usually cannot be shared between team members.