### PR TITLE
Linux fix permissions

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,7 +37,10 @@ Vagrant.configure(2) do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  config.vm.synced_folder "../magento2", "/var/www/magento2"
+  config.vm.synced_folder "../magento2", "/var/www/magento2",
+	owner: "vagrant",
+	group: "www-data",
+	mount_options: ["dmode=775,fmode=664"]
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.


### PR DESCRIPTION
Configured the sync folders permissions to fix the permission issues for www-data user when using a linux host box.
[PR#2](https://github.com/alankent/vagrant-magento2-apache-base/pull/2) is trying to address the same issue in a similar way.