### PR TITLE
Fixed typographical error, changed auxilary to auxiliary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,4 @@ See also
 
 (Future ideas include parameterizing so you can pick the web server (Apache or
 Nginx), pick the database server (MySQL, MariaDB, Percona etc), add Redis,
-Varnish etc auxilary servers. One day!)
+Varnish etc auxiliary servers. One day!)


### PR DESCRIPTION
alankent, I've corrected a typographical error in the documentation of the [vagrant-magento2-apache-base](https://github.com/alankent/vagrant-magento2-apache-base) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.